### PR TITLE
Fix timer label jumping in width

### DIFF
--- a/src/ui/timerpage.ui
+++ b/src/ui/timerpage.ui
@@ -26,6 +26,7 @@
             <property name="label">00:00</property>
             <style>
               <class name="time-label"/>
+              <class name="numeric"/>
             </style>
           </object>
         </child>


### PR DESCRIPTION
The timer label changes width depending on the numbers being displayed at the time. Using the 'numeric' style class solves this problem (it uses the 'tabular' number style).