### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/io.github.diegoivanme.flowtime.appdata.xml.in
+++ b/data/io.github.diegoivanme.flowtime.appdata.xml.in
@@ -30,7 +30,7 @@
 
   <releases>
     <release version="6.1" date="2023-11-10">
-      <description translatable="no">
+      <description translate="no">
         <p>Flowtime v6.1 has arrived with a couple of minor fixes and improvements</p>
         <ul>
           <li>Updated French Translation</li>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html