### PR TITLE
AppStream and README text improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ## Why?
 
-The Pomodoro technique is efficient for tasks you find boring, but having to take a break when you are 100% concentrated in something you like might be annoying. That's why the Flowtime technique exists: take appropriate breaks without loosing your **flow**.
+The Pomodoro technique is efficient for tasks you find boring, but having to take a break when you are 100% concentrated in something you like might be annoying. That's why the Flowtime technique exists: take appropriate breaks without losing your **flow**.
 
 ## How does it work?
 
@@ -41,7 +41,7 @@ The time you worked is divided by 5, and that's the break time you'll take. E.g,
 
 ### Flathub
 
-The only official distribution format for Flowtime is the Flatpak package available on Flathub. Click on the banner on the top of this README.md to go to Flowtime's Flathub page. Any other unofficial distribution format that might be available is highly disencouraged.
+The only official distribution format for Flowtime is the Flatpak package available on Flathub. Click on the banner on the top of this README.md to go to Flowtime's Flathub page. Any other unofficial distribution format that might be available are highly discouraged.
 
 ### Native Packages / Ports
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The time you worked is divided by 5, and that's the break time you'll take. E.g,
 
 ### Flathub
 
-The only official distribution format for Flowtime is the Flatpak package available on Flathub. Click on the banner on the top of this README.md to go to Flowtime's Flathub page. Any other unofficial distribution format that might be available are highly discouraged.
+The only official distribution format for Flowtime is the Flatpak package available on Flathub. Click on the banner on the top of this README.md to go to Flowtime's Flathub page. Any other unofficial distribution formats that might be available are highly discouraged.
 
 ### Native Packages / Ports
 

--- a/data/io.github.diegoivanme.flowtime.appdata.xml.in
+++ b/data/io.github.diegoivanme.flowtime.appdata.xml.in
@@ -9,7 +9,10 @@
 
 	<description>
 	  <p>
-	    The Pomodoro technique is efficient for tasks you find boring, but having to take a break when you are 100% concentrated in something you like might be annoying. That's why the Flowtime technique exists: take appropiate breaks without loosing you **flow**.
+	    The Pomodoro technique is efficient for tasks you find boring, but having to take a break when you are 100% concentrated in something you like might be annoying. That's why the Flowtime technique exists: take appropriate breaks without losing your flow.
+	  </p>
+	  <p>
+        Instead of strict work and break times, you work as long as you wish and your break is a portion of how long you worked (by default, 20%). For example, if you work for an hour, your break is 12 minutes. This lets you concentrate on your work and take appropriate breaks when convenient without a rigid schedule.
 	  </p>
 	</description>
 


### PR DESCRIPTION
Fixed typos like "loosing" instead of "losing" in AppStream and README. Replaced Markdown emphasis (\*\*flow**) with 
\<em> to conform to AppStream specification.

Wrote a small description of how the technique works for Flathub users because the original description is vague.

I believe these changes would make Flowtime more appealing for Flathub users.