### PR TITLE
Remove colon from credits section for consistency

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -145,7 +145,7 @@ namespace Flowtime {
                 website = "https://github.com/Diego-Ivan/Flowtime",
             };
 
-            about.add_credit_section (_("Sounds by: "), SOUND_ARTISTS);
+            about.add_credit_section (_("Sounds by"), SOUND_ARTISTS);
 
             about.present (this.active_window);
         }


### PR DESCRIPTION
Looking at the credit section we can see the default sections from Adwaita do not use a `:` colon, so that one looked out of place.

![image](https://github.com/user-attachments/assets/d2cf7a87-6f07-4060-98c5-ef85327e0a49)

So I have removed the colon for consistency with the rest of the sections.

The translation files might also need to be synchronized but I'm not sure how to do that
