### PR TITLE
feat: switch to work mode automatically when a break ends

### DIFF
--- a/src/Services/Timer.vala
+++ b/src/Services/Timer.vala
@@ -125,8 +125,8 @@ public class Flowtime.Services.Timer : Object {
             case BREAK:
                 if (time_seconds >= seconds) {
                     seconds = 0;
-                    running = false;
                     done ();
+                    next_mode ();
                     return false;
                 }
                 else {


### PR DESCRIPTION
To keep the user's flow, the work mode will be ready to start when a break ends, saving a few clicks.

https://github.com/user-attachments/assets/5a32cbf4-beb3-410c-9083-3952384cb570

fixes #104